### PR TITLE
Modification to the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
 1. Create the Setup Stack using setup.yaml template.  
    Inform your Personal Access Token as MyGitToken parameter  
 2. Create the Pipeline Stack using TemplatePipeline.yaml template  
-   Note: Use Setup parameter = true  
-3. Upload the TemplatePipeline.yaml file to S3 Bucket.  
+   Note: Use Setup parameter = true and modify the Default value of parameter GitHubOwner to your own GitHub username in TemplatePipeline.yaml template.
+3. Upload the edited TemplatePipeline.yaml file to S3 Bucket.  
    You can get the BucketName in the Output section for Setup Stack.   
 
 ### 3. Back to your Git Account:  


### PR DESCRIPTION
While testing this in my own account, I faced an error while creating an extra branch developer in my GitHub account as the default value of GitHubOwner was still being passed as hgbueno which should be passed as the user's own GitHub username. I feel if someone just follows the README.md file without looking at the template, they'd also come across this error message hence this change.